### PR TITLE
Provide SSL Support (#26)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,9 @@
   * `VAULT_SKIP_VERIFY` - 	If set, do not verify Vault's presented certificate before communicating with it. Setting this variable is not recommended except during testing.
   * `AUTH_METHODS` - Defines the auth types users can use. Supports "LDAP" and "Userpass". Specifying anything else will be seen as a custom userpass mount. Default is "Userpass"
   * `VAULT_PORT` - Defines the port vault uses for the health check. Default is 8200
+  * `VAULT_SSL_CERT` - Full path to the SSL cert used for https support
+  * `VAULT_SSL_KEY` - Full path to the SSL key used for the https support
+  * `VAULT_SSL_CA` - Full path to the SSL certificate authority used to verify VAUT_URL's cert when it uses https.
   
 ### Authentication
   * You must mount and setup an authentication backend before you can login to Vault UI. The easiest to get started with is userpass. For more information on setting up this backend, see the userpass [docs](https://www.vaultproject.io/docs/auth/userpass.html)

--- a/app.py
+++ b/app.py
@@ -108,4 +108,10 @@ def teapot():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=80)
+    if app.config['VAULT_SSL_CERT'] and app.config['VAULT_SSL_KEY']:
+       app.run(host='0.0.0.0', port=443, ssl_context=(app.config['VAULT_SSL_CERT'],app.config['VAULT_SSL_KEY']))
+    else:
+       print 'Warning:  Your secrets are being sent unencrypted over the network.'
+       print 'To enable SSL support. update the VAULT_SSL_CERT, VAULT_SSL_KEY, and VAULT_SSL_CA variables in settings.py'
+       app.run(host='0.0.0.0',  port=80)
+

--- a/settings.py
+++ b/settings.py
@@ -4,3 +4,6 @@ VAULT_URL = 'http://localhost:8200'
 VAULT_SKIP_VERIFY = False
 AUTH_METHODS = ["Userpass"]
 VAULT_PORT = 8200
+#VAULT_SSL_CERT = '/full/path/to/your/ssl.cert'
+#VAULT_SSL_KEY = '/full/path/to/your/ssl.key'
+#VAULT_SSL_CA = '/full/path/to/your/ssl-ca.crty'


### PR DESCRIPTION
- If VAULT_SSL_CERT, VAULT_SSL_KEY are defined in settings.py, then vault-ui is surfaced on port 443 with the ssl context defined by the VAULT_SSL_* values
- Added support to verify against a certificate authority if VAULT_SSL_CA is defined in settings.py (as per http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification)

(This is the single-commit version of the previous  PR #27)

